### PR TITLE
통계 관련 수정

### DIFF
--- a/service/statistics.go
+++ b/service/statistics.go
@@ -20,7 +20,7 @@ const (
 	DeviceTypePC     = DeviceType("pc")
 	DeviceTypeMobile = DeviceType("mobile")
 
-	UnknownValue      = ""
+	UnknownValue      = "(unknown)"
 )
 
 var sequenceRandomGenerator = initSequenceRandomGenerator()


### PR DESCRIPTION
1. TouchStatistics 호출 시 Referer, IPAddress 등 string 유형의 인자에 제공할 값이 없을 경우, 
새롭게 정의한 **UnknownValue** 상수를 대신 전달해주시기 바랍니다.

2. 이외에 시간 관련 정보를 범례로 사용하는 통계 정보에서 시간대를 제대로 처리하지 못하는 문제를 수정하였습니다.
